### PR TITLE
Close command fix

### DIFF
--- a/1_21/src/main/java/me/earth/headlessmc/mc/mixins/MixinLocalPlayer.java
+++ b/1_21/src/main/java/me/earth/headlessmc/mc/mixins/MixinLocalPlayer.java
@@ -56,7 +56,7 @@ public abstract class MixinLocalPlayer implements Player {
     @Override
     public void closeScreen() {
         if (Minecraft.getInstance().screen != null) {
-            Minecraft.getInstance().setScreen(null);
+            Minecraft.getInstance().screen.onClose();
         }
     }
 


### PR DESCRIPTION
Fix close command not working the same as closing an inventory manually (e.g. sending ServerboundContainerClosePacket, running onStopHovering)