### PR TITLE
Screen close fix

### DIFF
--- a/1_21/src/main/java/me/earth/headlessmc/mc/mixins/MixinLocalPlayer.java
+++ b/1_21/src/main/java/me/earth/headlessmc/mc/mixins/MixinLocalPlayer.java
@@ -38,13 +38,17 @@ public abstract class MixinLocalPlayer implements Player {
 
     @Override
     public void openMenu() {
-        Minecraft.getInstance().setScreen(null);
+        if (Minecraft.getInstance().screen != null) {
+            Minecraft.getInstance().screen.onClose();
+        }
         Minecraft.getInstance().pauseGame(false);
     }
 
     @Override
     public void openInventory() {
-        Minecraft.getInstance().setScreen(null);
+        if (Minecraft.getInstance().screen != null) {
+            Minecraft.getInstance().screen.onClose();
+        }
         if (Minecraft.getInstance().gameMode != null
             && Minecraft.getInstance().gameMode.isServerControlledInventory()) {
             LocalPlayer.class.cast(this).sendOpenInventory();
@@ -56,7 +60,7 @@ public abstract class MixinLocalPlayer implements Player {
     @Override
     public void closeScreen() {
         if (Minecraft.getInstance().screen != null) {
-            Minecraft.getInstance().setScreen(null);
+            Minecraft.getInstance().screen.onClose();
         }
     }
 


### PR DESCRIPTION
Fix screen closing in `menu`, `menu -inventory`, and `close` commands not working the same as closing an inventory manually (e.g. sending ServerboundContainerClosePacket or running onStopHovering)